### PR TITLE
Hardcode branch push trigger

### DIFF
--- a/.github/workflows/emoji-update.yml
+++ b/.github/workflows/emoji-update.yml
@@ -3,7 +3,7 @@ name: Emoji Update
 on:
   push:
     branches:
-      - $default-branch
+      - master
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Sadly the `$default-branch` is only supported in templates as a macro and not in actual workflows, so just set it to the current default branch name.